### PR TITLE
satellites sched and get involved updates

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -297,18 +297,30 @@
             .btn.btn-pink.get-involved-btn
               %a{href: "https://docs.google.com/forms/d/1_D9_jFoECa0B2qpMdiv-91QfyhSHlvKJ4RowIUsTZ4c/viewform"}
                 =t('dynamic_translations.get_involved.submit')
+          / .col-md-4
+          /   .title
+          /     =t('dynamic_translations.get_involved.contribute')
+          /   .btn.btn-pink.get-involved-btn
+          /     %a{href: "http://awards.ouishare.net/2015/applications/", target: "_blank"}
+          /       =t('dynamic_translations.get_involved_closed.submit')
           .col-md-4
             .title
-              =t('dynamic_translations.get_involved.contribute')
+              =t('dynamic_translations.awards.vote_txt')
             .btn.btn-pink.get-involved-btn
-              %a{href: "http://awards.ouishare.net/2015/applications/", target: "_blank"}
-                =t('dynamic_translations.get_involved_closed.submit')
+              %a{href: "http://awards.ouishare.net/2015/vote/", target: "_blank"}
+                =t('dynamic_translations.awards.vote_btn')
+          / .col-md-4
+          /   .title
+          /     =t('dynamic_translations.get_involved.idea_wall')
+          /   .btn.btn-pink.get-involved-btn
+          /     %a{href: "mailto:partners@ouishare.net", :target => "_blank"}
+          /       = t('dynamic_translations.get_involved.idea_wall_button')
           .col-md-4
             .title
-              =t('dynamic_translations.get_involved.idea_wall')
+              =t('dynamic_translations.pitch_startup.txt')
             .btn.btn-pink.get-involved-btn
-              %a{href: "mailto:partners@ouishare.net", :target => "_blank"}
-                = t('dynamic_translations.get_involved.idea_wall_button')
+              %a{href: "https://docs.google.com/forms/d/1tMbjJHx8SdZb-hp7jm8Q5SfJwh5NEJc2KjwBw35cVhg/viewform", :target => "_blank"}
+                = t('dynamic_translations.pitch_startup.btn')
 
 
 .ouishare-news-section

--- a/app/views/home/join.html.haml
+++ b/app/views/home/join.html.haml
@@ -67,18 +67,30 @@
             .btn.btn-pink.get-involved-btn
               %a{href: "https://docs.google.com/forms/d/1_D9_jFoECa0B2qpMdiv-91QfyhSHlvKJ4RowIUsTZ4c/viewform"}
                 =t('dynamic_translations.get_involved.submit')
+          / .col-md-4
+          /   .title
+          /     =t('dynamic_translations.get_involved.contribute')
+          /   .btn.btn-pink.get-involved-btn
+          /     %a{href: "http://awards.ouishare.net/2015/applications/", target: "_blank"}
+          /       =t('dynamic_translations.get_involved_closed.submit')
           .col-md-4
             .title
-              =t('dynamic_translations.get_involved.contribute')
+              =t('dynamic_translations.awards.vote_txt')
             .btn.btn-pink.get-involved-btn
-              %a{href: "http://awards.ouishare.net/2015/applications/", target: "_blank"}
-                =t('dynamic_translations.get_involved_closed.submit')
+              %a{href: "http://awards.ouishare.net/2015/vote/", target: "_blank"}
+                =t('dynamic_translations.awards.vote_btn')
+          / .col-md-4
+          /   .title
+          /     =t('dynamic_translations.get_involved.idea_wall')
+          /   .btn.btn-pink.get-involved-btn
+          /     %a{href: "mailto:partners@ouishare.net", :target => "_blank"}
+          /       = t('dynamic_translations.get_involved.idea_wall_button')
           .col-md-4
             .title
-              =t('dynamic_translations.get_involved.idea_wall')
+              =t('dynamic_translations.pitch_startup.txt')
             .btn.btn-pink.get-involved-btn
-              %a{href: "mailto:partners@ouishare.net", :target => "_blank"}
-                = t('dynamic_translations.get_involved.idea_wall_button')
+              %a{href: "https://docs.google.com/forms/d/1tMbjJHx8SdZb-hp7jm8Q5SfJwh5NEJc2KjwBw35cVhg/viewform", :target => "_blank"}
+                = t('dynamic_translations.pitch_startup.btn')
 
 
 

--- a/app/views/home/program.html.haml
+++ b/app/views/home/program.html.haml
@@ -218,10 +218,9 @@
 
   .container.events-section
     .row
-      %a#sched-embed{:href => "http://ouisharefestsatelliteevents2015.sched.org/"}
-      %script{:type => "text/javascript", :src => "http://ouisharefestsatelliteevents2015.sched.org/js/embed.js"}
-
-  /     .col-md-10.col-md-offset-1
+      .col-md-10.col-md-offset-1
+        %a#sched-embed{:href => "http://ouisharefestsatelliteevents2015.sched.org/"}
+        %script{:type => "text/javascript", :src => "http://ouisharefestsatelliteevents2015.sched.org/js/embed.js"}
   /       %a{:href => 'https://oscedays.org/#clients', :target => '_blank'}
   /         .row
   /           .col-md-12
@@ -348,6 +347,8 @@
               .btn.btn-pink{:style => 'margin: 40px 0px 0px 0px;'}
                 %a{:href => 'http://www.digitick.com/ouishare-love-3-soiree-cabaret-sauvage-paris-22-mai-2015-css4-digitick-pg101-ri3193590.html', :target => '_blank'}
                   = t('dynamic_translations.love_party.see_lineup')
+              %br
+              %br
             .col-md-12
               %img.img-responsive{:src => '/assets/loveparty2015.png', :alt => 'love party picture', :style => 'width:400px;margin:auto;'}
 

--- a/app/views/home/program.html.haml
+++ b/app/views/home/program.html.haml
@@ -173,8 +173,8 @@
               %a{:href => '/satellite_events', :target => '_blank'}
                 = t('dynamic_translations.satellite_events.read_more')
 
-  %br
-  %br
+  / %br
+  / %br
 
   /     .row
   /       %a{:href => 'https://docs.google.com/forms/d/1xwFAL9C5AHZgBAeC6tGD6_eX0Ca1u00ZawZEueHczII/viewform', :target => '_blank'}

--- a/app/views/home/program.html.haml
+++ b/app/views/home/program.html.haml
@@ -166,6 +166,13 @@
       .col-md-8.col-md-offset-2
         %p.main-section-paragraphes.centered
           = t('dynamic_translations.satellite_events.text')
+      .row.centered
+        .col-md-10.col-md-offset-1
+          .col-md-12
+            .btn.btn-pink{:style => 'margin: 40px 0px 0px 0px;'}
+              %a{:href => '/satellite_events', :target => '_blank'}
+                = t('dynamic_translations.satellite_events.read_more')
+
   %br
   %br
 
@@ -216,13 +223,10 @@
   /           18.05 to 19.05 9am - 6pm
 
 
-  .container.events-section
-    .row
-      .col-md-10.col-md-offset-1
-        %a#sched-embed{:href => "http://ouisharefestsatelliteevents2015.sched.org/"}
-          schedule
-        %script{:type => "text/javascript", :src => "http://ouisharefestsatelliteevents2015.sched.org/js/embed.js"}
-  
+  / .container.events-section
+  /   .row
+
+  /     .col-md-10.col-md-offset-1
   /       %a{:href => 'https://oscedays.org/#clients', :target => '_blank'}
   /         .row
   /           .col-md-12
@@ -346,11 +350,9 @@
         .row
           .col-md-10.col-md-offset-1
             .col-md-12
-              .btn.btn-pink{:style => 'margin: 40px 0px 0px 0px;'}
+              .btn.btn-pink{:style => 'margin: 0px 0px 40px 0px;'}
                 %a{:href => 'http://www.digitick.com/ouishare-love-3-soiree-cabaret-sauvage-paris-22-mai-2015-css4-digitick-pg101-ri3193590.html', :target => '_blank'}
                   = t('dynamic_translations.love_party.see_lineup')
-              %br
-              %br
             .col-md-12
               %img.img-responsive{:src => '/assets/loveparty2015.png', :alt => 'love party picture', :style => 'width:400px;margin:auto;'}
 

--- a/app/views/home/program.html.haml
+++ b/app/views/home/program.html.haml
@@ -220,7 +220,9 @@
     .row
       .col-md-10.col-md-offset-1
         %a#sched-embed{:href => "http://ouisharefestsatelliteevents2015.sched.org/"}
+          schedule
         %script{:type => "text/javascript", :src => "http://ouisharefestsatelliteevents2015.sched.org/js/embed.js"}
+  
   /       %a{:href => 'https://oscedays.org/#clients', :target => '_blank'}
   /         .row
   /           .col-md-12

--- a/app/views/home/program.html.haml
+++ b/app/views/home/program.html.haml
@@ -218,116 +218,116 @@
 
   .container.events-section
     .row
+      %a#sched-embed{:href => "http://ouisharefestsatelliteevents2015.sched.org/"}
+      %script{:type => "text/javascript", :src => "http://ouisharefestsatelliteevents2015.sched.org/js/embed.js"}
 
-      .col-md-10.col-md-offset-1
-        %a{:href => 'https://oscedays.org/#clients', :target => '_blank'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  OSCE days 15
-                %p
-                  11.05 to 15.06
-        %a{:href => 'http://camp.ouisharelabs.net/2015/', :target => '_blank'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  OuiShare Labs Camp
-                %p
-                  18.05 to 19.05 9am - 6pm
-                %p
-                  Mozilla Paris
-                %p
-                  16 Bis Boulevard Montmartre 75009 Paris
-        %a{:href => 'http://www.collegedesbernardins.fr/images/pdf/formation/2015-depliant_MDB.pdf'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  L’économie du partage mérite-t-elle son nom ?
-                %p
-                  19.05 8pm - 9.45pm
-                %p
-                  Collège des Bernardins
-                %p
-                  20 rue de Poissy - 75005 Paris
-        %a{:href => 'https://www.couchsurfing.com/events/drinks-at-ouishare-w-ceo-of-couchsurfing', :target => '_blank'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  Drinks at Ouishare w/CEO of Couchsurfing
-                %p
-                  21.05 6pm - 7.30pm
-                %p
-                  Restaurant Les Moulins
-                %p
-                  78 rue Compans 75019 PARIS
-        %a{:href => 'http://www.arts-et-metiers.net/musee/fini-la-propriete-vive-lusage'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  Rencontre débat : "Fini la propriété, vive l’usage !"
-                %p
-                  21.05 6.30pm - 8pm
-                %p
-                  Cnam : Musée des arts et métiers. Salle de conférences
-                %p
-                  Musée des arts et métiers, 60 rue Réaumur, Paris 3e
-        %a{:href => 'http://events.newschool.edu/event/earth_day_2015_the_remaking_of_making#.VS9zovmsXhK', :target => '_blank'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  Roundtable: The Remaking of Making
-                %p
-                  22.05 6.30pm - 8pm
-                %p
-                  Parsons Paris
-                %p
-                  45 Rue Saint-Roch 75001 Paris
-        %a{:href => 'http://www.digitick.com/ouishare-love-3-soiree-cabaret-sauvage-paris-22-mai-2015-css4-digitick-pg101-ri3193590.html', :target => '_blank'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  OuiShare Love Party
-                %p
-                  22.05 11pm - 5am
-                %p
-                  Cabaret Sauvage
-                %p
-                  Parc de la Villette, 211 Avenue Jean Jaures, Paris
-        %a{:href => 'https://www.facebook.com/events/1613389028892817/'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  Collaboration Camp
-                %p
-                  23.05 to 26.05 at 5pm
-                %p
-                  TBC
-                %p
-                  TBC
-        %a{:href => 'http://www.futurearchitecture.org/', :target => '_blank'}
-          .row
-            .col-md-12
-              .event-block
-                %h6
-                  Future Architecture Night
-                %p
-                  26.05 6.30pm - 10.30pm
-                %p
-                  Volumes Coworking
-                %p
-                  78 rue Compans 75019 PARIS
+  /     .col-md-10.col-md-offset-1
+  /       %a{:href => 'https://oscedays.org/#clients', :target => '_blank'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 OSCE days 15
+  /               %p
+  /                 11.05 to 15.06
+  /       %a{:href => 'http://camp.ouisharelabs.net/2015/', :target => '_blank'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 OuiShare Labs Camp
+  /               %p
+  /                 18.05 to 19.05 9am - 6pm
+  /               %p
+  /                 Mozilla Paris
+  /               %p
+  /                 16 Bis Boulevard Montmartre 75009 Paris
+  /       %a{:href => 'http://www.collegedesbernardins.fr/images/pdf/formation/2015-depliant_MDB.pdf'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 L’économie du partage mérite-t-elle son nom ?
+  /               %p
+  /                 19.05 8pm - 9.45pm
+  /               %p
+  /                 Collège des Bernardins
+  /               %p
+  /                 20 rue de Poissy - 75005 Paris
+  /       %a{:href => 'https://www.couchsurfing.com/events/drinks-at-ouishare-w-ceo-of-couchsurfing', :target => '_blank'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 Drinks at Ouishare w/CEO of Couchsurfing
+  /               %p
+  /                 21.05 6pm - 7.30pm
+  /               %p
+  /                 Restaurant Les Moulins
+  /               %p
+  /                 78 rue Compans 75019 PARIS
+  /       %a{:href => 'http://www.arts-et-metiers.net/musee/fini-la-propriete-vive-lusage'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 Rencontre débat : "Fini la propriété, vive l’usage !"
+  /               %p
+  /                 21.05 6.30pm - 8pm
+  /               %p
+  /                 Cnam : Musée des arts et métiers. Salle de conférences
+  /               %p
+  /                 Musée des arts et métiers, 60 rue Réaumur, Paris 3e
+  /       %a{:href => 'http://events.newschool.edu/event/earth_day_2015_the_remaking_of_making#.VS9zovmsXhK', :target => '_blank'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 Roundtable: The Remaking of Making
+  /               %p
+  /                 22.05 6.30pm - 8pm
+  /               %p
+  /                 Parsons Paris
+  /               %p
+  /                 45 Rue Saint-Roch 75001 Paris
+  /       %a{:href => 'http://www.digitick.com/ouishare-love-3-soiree-cabaret-sauvage-paris-22-mai-2015-css4-digitick-pg101-ri3193590.html', :target => '_blank'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 OuiShare Love Party
+  /               %p
+  /                 22.05 11pm - 5am
+  /               %p
+  /                 Cabaret Sauvage
+  /               %p
+  /                 Parc de la Villette, 211 Avenue Jean Jaures, Paris
+  /       %a{:href => 'https://www.facebook.com/events/1613389028892817/'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 Collaboration Camp
+  /               %p
+  /                 23.05 to 26.05 at 5pm
+  /               %p
+  /                 TBC
+  /               %p
+  /                 TBC
+  /       %a{:href => 'http://www.futurearchitecture.org/', :target => '_blank'}
+  /         .row
+  /           .col-md-12
+  /             .event-block
+  /               %h6
+  /                 Future Architecture Night
+  /               %p
+  /                 26.05 6.30pm - 10.30pm
+  /               %p
+  /                 Volumes Coworking
+  /               %p
+  /                 78 rue Compans 75019 PARIS
 
-
-
-/ Love Party
+  / Love Party
 #_love_party.aboutouishare-section
   .container
     .row.centered
@@ -345,11 +345,12 @@
         .row
           .col-md-10.col-md-offset-1
             .col-md-12
-              %img.img-responsive{:src => '/assets/loveparty2015.png', :alt => 'love party picture', :style => 'width:400px;margin:auto;'}
-            .col-md-12
               .btn.btn-pink{:style => 'margin: 40px 0px 0px 0px;'}
                 %a{:href => 'http://www.digitick.com/ouishare-love-3-soiree-cabaret-sauvage-paris-22-mai-2015-css4-digitick-pg101-ri3193590.html', :target => '_blank'}
                   = t('dynamic_translations.love_party.see_lineup')
+            .col-md-12
+              %img.img-responsive{:src => '/assets/loveparty2015.png', :alt => 'love party picture', :style => 'width:400px;margin:auto;'}
+
 
 / .triangle_bg#_love_party
 /   .container

--- a/app/views/home/satellite_events.haml
+++ b/app/views/home/satellite_events.haml
@@ -1,0 +1,21 @@
+.blank_bg
+  .container
+    .row.centered
+      %h3.ouishare_stencil.pink
+        = t('dynamic_translations.satellite_events.title')
+      %hr.pink
+    %br
+    %br
+    .main-section
+      .col-md-8.col-md-offset-2
+        %p.main-section-paragraphes.centered
+          = t('dynamic_translations.satellite_events.text')
+  %br
+  %br
+
+  .container.events-section
+    .row
+      .col-md-10.col-md-offset-1
+        %a#sched-embed{:href => "http://ouisharefestsatelliteevents2015.sched.org/"}
+          schedule
+        %script{:type => "text/javascript", :src => "http://ouisharefestsatelliteevents2015.sched.org/js/embed.js"}

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -111,7 +111,7 @@
             /   %a{href: "program#_sharing_fair"}
             /     = t('dynamic_translations.sharing_fair.title')
             %li
-              %a{href: "program#_events"}
+              %a{href: "/satellite_events"}
                 = t('dynamic_translations.program.satellite_events')
             %li
               %a{href: "program#_love_party"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ OuiShareFest::Application.routes.draw do
     get :where_to_stay
     get :getting_to_the_venue
     get :zero_waste_event
+    get :satellite_events
     # get :stories
     post :newsletter_collect_email
   end


### PR DESCRIPTION
- display satellite events as a sched embed --> had to create a new page /satellite_events because sched does not show 2 embeds on the same page
- hide static satellites display
- add button to target new page

- love party button move
- get involved replace 2 buttons on index and join: add startup pitches, awards votes, hide partner btn
